### PR TITLE
Allocate IP for new ECS server

### DIFF
--- a/lib/fog/aliyun/compute.rb
+++ b/lib/fog/aliyun/compute.rb
@@ -72,6 +72,8 @@ module Fog
       request :associate_eip_address
       request :unassociate_eip_address
 
+      # IP
+      request :allocate_public_ip_address
 
       # Security Group
       request :list_security_groups


### PR DESCRIPTION
https://help.aliyun.com/document_detail/ecs/open-api/network/allocatepublicipaddress.html?spm=5176.docecs/open-api/ram/ecsrule.6.221.vHru9g
