### PR TITLE
Handled nil when assigning snapshot_id in image

### DIFF
--- a/lib/fog/aliyun/models/compute/image.rb
+++ b/lib/fog/aliyun/models/compute/image.rb
@@ -29,7 +29,9 @@ module Fog
         attribute :snapshot_id, aliases: 'SnapshotId'
 
         def initialize(attributes)
-          self.snapshot_id = attributes['DiskDeviceMappings']['DiskDeviceMapping'][0]['SnapshotId']
+          unless attributes['DiskDeviceMappings']['DiskDeviceMapping'].empty?
+            self.snapshot_id = attributes['DiskDeviceMappings']['DiskDeviceMapping'][0]['SnapshotId']
+          end
           super
         end
 


### PR DESCRIPTION
There is no `DiskDeviceMapping` data present i.e empty array in my case.
While a listing images using `.images`, it is giving `NoMethodError: undefined method `[]' for nil:NilClass`. 

With this change, it loads images objects properly.