### PR TITLE
Introduce a new pattern for passing querystring values as a hash

### DIFF
--- a/lib/fog/aliyun/models/compute/server.rb
+++ b/lib/fog/aliyun/models/compute/server.rb
@@ -36,7 +36,7 @@ module Fog
         attribute :expired_at, aliases: 'ExpiredTime'
 
         def image
-          requires image_id
+          requires :image_id
           Fog::Compute::Aliyun::Image.new(service: service).all(imageId: image_id)[0]
         end
 

--- a/lib/fog/aliyun/requests/compute/list_server_types.rb
+++ b/lib/fog/aliyun/requests/compute/list_server_types.rb
@@ -41,7 +41,7 @@ module Fog
           )
 
           _InstanceTypeId = nil
-          _InstanceTypeList = Fog::JSON.decode(response.body)['InstanceTypes']['InstanceType']
+          _InstanceTypeList = response.body['InstanceTypes']['InstanceType']
           _InstanceTypeList.each do |instance_type|
             next unless (instance_type['CpuCoreCount'] == cpuCount) && (instance_type['MemorySize'] == memorySize)
             _InstanceTypeId = instance_type['InstanceTypeId']

--- a/lib/fog/aliyun/requests/compute/list_servers.rb
+++ b/lib/fog/aliyun/requests/compute/list_servers.rb
@@ -11,7 +11,7 @@ module Fog
           _time = Time.new.utc
 
           _parameters = defalutParameters(_action, _sigNonce, _time)
-          _pathURL = defaultAliyunUri(_action, _sigNonce, _time)
+          _query_parameters = defaultAliyunQueryParameters(_action, _sigNonce, _time)
 
           _InstanceId = options[:instanceId]
           _VpcId = options[:vpcId]
@@ -22,35 +22,35 @@ module Fog
           unless _InstanceId.nil?
             _InstanceStr = "[\"#{_InstanceId}\"]"
             _parameters['InstanceIds'] = _InstanceStr
-            _pathURL += '&InstanceIds=' + _InstanceStr
+            _query_parameters[:InstanceIds] = _InstanceStr
           end
 
           unless _VpcId.nil?
             _parameters['VpcId'] = _VpcId
-            _pathURL += '&VpcId=' + _VpcId
+            _query_parameters[:VpcId] = _VpcId
           end
 
           unless _SecurityGroupId.nil?
             _parameters['SecurityGroupId'] = _SecurityGroupId
-            _pathURL += '&SecurityGroupId=' + _SecurityGroupId
+            _query_parameters[:SecurityGroupId] = _SecurityGroupId
           end
 
           unless _PageNumber.nil?
             _parameters['PageNumber'] = _PageNumber
-            _pathURL += '&PageNumber=' + _PageNumber
+            _query_parameters[:PageNumber] = _PageNumber
           end
 
           _PageSize ||= '50'
           _parameters['PageSize'] = _PageSize
-          _pathURL += '&PageSize=' + _PageSize
+          _query_parameters[:PageSize] = _PageSize
 
-          _signature = sign(@aliyun_accesskey_secret, _parameters)
-          _pathURL += '&Signature=' + _signature
+          _signature = sign_without_encoding(@aliyun_accesskey_secret, _parameters)
+          _query_parameters[:Signature] = _signature
 
           request(
             expects: [200, 203],
             method: 'GET',
-            path: _pathURL
+            query: _query_parameters
           )
         end
       end


### PR DESCRIPTION
This refactors the gem to no longer build querystrings with string concatenation and, instead, passes a hash to the underlying request library.

This commit only implements the new pattern in the `list_servers` request to be used as a guideline.