### PR TITLE
Fix param to :vpcId

### DIFF
--- a/lib/fog/aliyun/models/compute/vpcs.rb
+++ b/lib/fog/aliyun/models/compute/vpcs.rb
@@ -72,7 +72,7 @@ module Fog
         #
 
         def get(vpcId)
-          $vpc = self.class.new(service: service).all('vpcId' => vpcId)[0] if vpcId
+          $vpc = self.class.new(service: service).all(:vpcId => vpcId)[0] if vpcId
         end
       end
     end


### PR DESCRIPTION
The get method of vpcs accepts vpcId and then it passes that to all method. Here vpcId should be :vpcId instead 'vpcId' as list_vpcs request call checks for :vpcId . This fixes the issue and allows to pull details about specific vpc.