### PR TITLE
fix defaultParameters spelling

### DIFF
--- a/lib/fog/aliyun/compute.rb
+++ b/lib/fog/aliyun/compute.rb
@@ -380,7 +380,7 @@ module Fog
         end
 
         # operation compute--collection of default parameters
-        def defalutParameters(action, sigNonce, time)
+        def defaultParameters(action, sigNonce, time)
           parTimeFormat = time.strftime('%Y-%m-%dT%H:%M:%SZ')
           para = {
             'Format' => 'JSON',
@@ -413,7 +413,7 @@ module Fog
         end
 
         # compute signature
-        # This method should be considered deprecated and replaced with sign_without_encoding, which is better for using querystring hashes and not 
+        # This method should be considered deprecated and replaced with sign_without_encoding, which is better for using querystring hashes and not
         # building querystrings with string concatination.
         def sign(accessKeySecret, parameters)
           signature = sign_without_encoding(accessKeySecret, parameters)

--- a/lib/fog/aliyun/requests/compute/allocate_eip_address.rb
+++ b/lib/fog/aliyun/requests/compute/allocate_eip_address.rb
@@ -26,7 +26,7 @@ module Fog
           _sigNonce = randonStr
           _time = Time.new.utc
 
-          _parameters = defalutParameters(_action, _sigNonce, _time)
+          _parameters = defaultParameters(_action, _sigNonce, _time)
           _pathURL = defaultAliyunUri(_action, _sigNonce, _time)
 
           # optional parameters

--- a/lib/fog/aliyun/requests/compute/allocate_public_ip_address.rb
+++ b/lib/fog/aliyun/requests/compute/allocate_public_ip_address.rb
@@ -20,7 +20,7 @@ module Fog
           _sigNonce = randonStr
           _time = Time.new.utc
 
-          _parameters = defalutParameters(_action, _sigNonce, _time)
+          _parameters = defaultParameters(_action, _sigNonce, _time)
           _pathURL = defaultAliyunUri(_action, _sigNonce, _time)
 
           _parameters['InstanceId'] = server_id

--- a/lib/fog/aliyun/requests/compute/associate_eip_address.rb
+++ b/lib/fog/aliyun/requests/compute/associate_eip_address.rb
@@ -22,7 +22,7 @@ module Fog
 
           type = options['instance_type']
 
-          _parameters = defalutParameters(_action, _sigNonce, _time)
+          _parameters = defaultParameters(_action, _sigNonce, _time)
           _pathURL = defaultAliyunUri(_action, _sigNonce, _time)
 
           _parameters['InstanceId'] = server_id

--- a/lib/fog/aliyun/requests/compute/attach_disk.rb
+++ b/lib/fog/aliyun/requests/compute/attach_disk.rb
@@ -23,7 +23,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['InstanceId'] = instanceId

--- a/lib/fog/aliyun/requests/compute/create_disk.rb
+++ b/lib/fog/aliyun/requests/compute/create_disk.rb
@@ -25,7 +25,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['ZoneId'] = @aliyun_zone_id
@@ -90,7 +90,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['ZoneId'] = @aliyun_zone_id

--- a/lib/fog/aliyun/requests/compute/create_image.rb
+++ b/lib/fog/aliyun/requests/compute/create_image.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['SnapshotId'] = snapshotId

--- a/lib/fog/aliyun/requests/compute/create_security_group.rb
+++ b/lib/fog/aliyun/requests/compute/create_security_group.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           name = options[:name]

--- a/lib/fog/aliyun/requests/compute/create_security_group_egress_ip_rule.rb
+++ b/lib/fog/aliyun/requests/compute/create_security_group_egress_ip_rule.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['SecurityGroupId'] = securitygroup_id

--- a/lib/fog/aliyun/requests/compute/create_security_group_egress_sg_rule.rb
+++ b/lib/fog/aliyun/requests/compute/create_security_group_egress_sg_rule.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['SecurityGroupId'] = securitygroup_id

--- a/lib/fog/aliyun/requests/compute/create_security_group_ip_rule.rb
+++ b/lib/fog/aliyun/requests/compute/create_security_group_ip_rule.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['SecurityGroupId'] = securitygroup_id

--- a/lib/fog/aliyun/requests/compute/create_security_group_sg_rule.rb
+++ b/lib/fog/aliyun/requests/compute/create_security_group_sg_rule.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['SecurityGroupId'] = securitygroup_id

--- a/lib/fog/aliyun/requests/compute/create_server.rb
+++ b/lib/fog/aliyun/requests/compute/create_server.rb
@@ -10,7 +10,7 @@ module Fog
           _sigNonce = randonStr
           _time = Time.new.utc
 
-          _parameters = defalutParameters(_action, _sigNonce, _time)
+          _parameters = defaultParameters(_action, _sigNonce, _time)
           _pathURL = defaultAliyunUri(_action, _sigNonce, _time)
 
           _parameters['ImageId'] = imageId

--- a/lib/fog/aliyun/requests/compute/create_snapshot.rb
+++ b/lib/fog/aliyun/requests/compute/create_snapshot.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['DiskId'] = diskId

--- a/lib/fog/aliyun/requests/compute/create_vpc.rb
+++ b/lib/fog/aliyun/requests/compute/create_vpc.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['CidrBlock'] = cidrBlock

--- a/lib/fog/aliyun/requests/compute/create_vswitch.rb
+++ b/lib/fog/aliyun/requests/compute/create_vswitch.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['VpcId'] = vpcId

--- a/lib/fog/aliyun/requests/compute/delete_disk.rb
+++ b/lib/fog/aliyun/requests/compute/delete_disk.rb
@@ -20,7 +20,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['DiskId'] = diskId

--- a/lib/fog/aliyun/requests/compute/delete_image.rb
+++ b/lib/fog/aliyun/requests/compute/delete_image.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['ImageId'] = imageId

--- a/lib/fog/aliyun/requests/compute/delete_security_group.rb
+++ b/lib/fog/aliyun/requests/compute/delete_security_group.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           if security_group_id

--- a/lib/fog/aliyun/requests/compute/delete_security_group_egress_ip_rule.rb
+++ b/lib/fog/aliyun/requests/compute/delete_security_group_egress_ip_rule.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['SecurityGroupId'] = securitygroup_id

--- a/lib/fog/aliyun/requests/compute/delete_security_group_egress_sg_rule.rb
+++ b/lib/fog/aliyun/requests/compute/delete_security_group_egress_sg_rule.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['SecurityGroupId'] = securitygroup_id

--- a/lib/fog/aliyun/requests/compute/delete_security_group_ip_rule.rb
+++ b/lib/fog/aliyun/requests/compute/delete_security_group_ip_rule.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['SecurityGroupId'] = securitygroup_id

--- a/lib/fog/aliyun/requests/compute/delete_security_group_sg_rule.rb
+++ b/lib/fog/aliyun/requests/compute/delete_security_group_sg_rule.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['SecurityGroupId'] = securitygroup_id

--- a/lib/fog/aliyun/requests/compute/delete_server.rb
+++ b/lib/fog/aliyun/requests/compute/delete_server.rb
@@ -10,7 +10,7 @@ module Fog
           _sigNonce = randonStr
           _time = Time.new.utc
 
-          _parameters = defalutParameters(_action, _sigNonce, _time)
+          _parameters = defaultParameters(_action, _sigNonce, _time)
           _pathURL = defaultAliyunUri(_action, _sigNonce, _time)
 
           _parameters['InstanceId'] = server_id

--- a/lib/fog/aliyun/requests/compute/delete_snapshot.rb
+++ b/lib/fog/aliyun/requests/compute/delete_snapshot.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['SnapshotId'] = snapshotId

--- a/lib/fog/aliyun/requests/compute/delete_vpc.rb
+++ b/lib/fog/aliyun/requests/compute/delete_vpc.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           if vpc_id

--- a/lib/fog/aliyun/requests/compute/delete_vswitch.rb
+++ b/lib/fog/aliyun/requests/compute/delete_vswitch.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           if vswitch_id

--- a/lib/fog/aliyun/requests/compute/detach_disk.rb
+++ b/lib/fog/aliyun/requests/compute/detach_disk.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['InstanceId'] = instanceId

--- a/lib/fog/aliyun/requests/compute/join_security_group.rb
+++ b/lib/fog/aliyun/requests/compute/join_security_group.rb
@@ -10,7 +10,7 @@ module Fog
           _sigNonce = randonStr
           _time = Time.new.utc
 
-          _parameters = defalutParameters(_action, _sigNonce, _time)
+          _parameters = defaultParameters(_action, _sigNonce, _time)
           _pathURL = defaultAliyunUri(_action, _sigNonce, _time)
 
           _parameters['InstanceId'] = server_id

--- a/lib/fog/aliyun/requests/compute/leave_security_group.rb
+++ b/lib/fog/aliyun/requests/compute/leave_security_group.rb
@@ -10,7 +10,7 @@ module Fog
           _sigNonce = randonStr
           _time = Time.new.utc
 
-          _parameters = defalutParameters(_action, _sigNonce, _time)
+          _parameters = defaultParameters(_action, _sigNonce, _time)
           _pathURL = defaultAliyunUri(_action, _sigNonce, _time)
 
           _parameters['InstanceId'] = server_id

--- a/lib/fog/aliyun/requests/compute/list_disks.rb
+++ b/lib/fog/aliyun/requests/compute/list_disks.rb
@@ -34,7 +34,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           pageNumber = options[:pageNumber]

--- a/lib/fog/aliyun/requests/compute/list_eip_addresses.rb
+++ b/lib/fog/aliyun/requests/compute/list_eip_addresses.rb
@@ -10,7 +10,7 @@ module Fog
           _sigNonce = randonStr
           _time = Time.new.utc
 
-          _parameters = defalutParameters(_action, _sigNonce, _time)
+          _parameters = defaultParameters(_action, _sigNonce, _time)
           _pathURL = defaultAliyunUri(_action, _sigNonce, _time)
 
           _Status = options[:state]

--- a/lib/fog/aliyun/requests/compute/list_images.rb
+++ b/lib/fog/aliyun/requests/compute/list_images.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           pageNumber = options[:pageNumber]

--- a/lib/fog/aliyun/requests/compute/list_route_tables.rb
+++ b/lib/fog/aliyun/requests/compute/list_route_tables.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['VRouterId'] = vrouterid

--- a/lib/fog/aliyun/requests/compute/list_security_group_rules.rb
+++ b/lib/fog/aliyun/requests/compute/list_security_group_rules.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['SecurityGroupId'] = securityGroupId

--- a/lib/fog/aliyun/requests/compute/list_security_groups.rb
+++ b/lib/fog/aliyun/requests/compute/list_security_groups.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           pageNumber = options[:pageNumber]

--- a/lib/fog/aliyun/requests/compute/list_server_types.rb
+++ b/lib/fog/aliyun/requests/compute/list_server_types.rb
@@ -10,7 +10,7 @@ module Fog
           _sigNonce = randonStr
           _time = Time.new.utc
 
-          _parameters = defalutParameters(_action, _sigNonce, _time)
+          _parameters = defaultParameters(_action, _sigNonce, _time)
           _pathURL = defaultAliyunUri(_action, _sigNonce, _time)
 
           _signature = sign(@aliyun_accesskey_secret, _parameters)
@@ -28,7 +28,7 @@ module Fog
           _sigNonce = randonStr
           _time = Time.new.utc
 
-          _parameters = defalutParameters(_action, _sigNonce, _time)
+          _parameters = defaultParameters(_action, _sigNonce, _time)
           _pathURL = defaultAliyunUri(_action, _sigNonce, _time)
 
           _signature = sign(@aliyun_accesskey_secret, _parameters)

--- a/lib/fog/aliyun/requests/compute/list_servers.rb
+++ b/lib/fog/aliyun/requests/compute/list_servers.rb
@@ -10,7 +10,7 @@ module Fog
           _sigNonce = randonStr
           _time = Time.new.utc
 
-          _parameters = defalutParameters(_action, _sigNonce, _time)
+          _parameters = defaultParameters(_action, _sigNonce, _time)
           _query_parameters = defaultAliyunQueryParameters(_action, _sigNonce, _time)
 
           _InstanceId = options[:instanceId]

--- a/lib/fog/aliyun/requests/compute/list_snapshots.rb
+++ b/lib/fog/aliyun/requests/compute/list_snapshots.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           pageNumber = options[:pageNumber]

--- a/lib/fog/aliyun/requests/compute/list_vpcs.rb
+++ b/lib/fog/aliyun/requests/compute/list_vpcs.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           _VpcId = options[:vpcId]

--- a/lib/fog/aliyun/requests/compute/list_vrouters.rb
+++ b/lib/fog/aliyun/requests/compute/list_vrouters.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           _VRouterId = options[:vRouterId]

--- a/lib/fog/aliyun/requests/compute/list_vswitchs.rb
+++ b/lib/fog/aliyun/requests/compute/list_vswitchs.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['VpcId'] = vpcid

--- a/lib/fog/aliyun/requests/compute/list_zones.rb
+++ b/lib/fog/aliyun/requests/compute/list_zones.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           signature = sign(@aliyun_accesskey_secret, parameters)

--- a/lib/fog/aliyun/requests/compute/modify_vpc.rb
+++ b/lib/fog/aliyun/requests/compute/modify_vpc.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['VpcId'] = vpcId

--- a/lib/fog/aliyun/requests/compute/modify_vswitch.rb
+++ b/lib/fog/aliyun/requests/compute/modify_vswitch.rb
@@ -10,7 +10,7 @@ module Fog
           sigNonce = randonStr
           time = Time.new.utc
 
-          parameters = defalutParameters(action, sigNonce, time)
+          parameters = defaultParameters(action, sigNonce, time)
           pathUrl = defaultAliyunUri(action, sigNonce, time)
 
           parameters['VSwitchId'] = vSwitchId

--- a/lib/fog/aliyun/requests/compute/reboot_server.rb
+++ b/lib/fog/aliyun/requests/compute/reboot_server.rb
@@ -10,7 +10,7 @@ module Fog
           _sigNonce = randonStr
           _time = Time.new.utc
 
-          _parameters = defalutParameters(_action, _sigNonce, _time)
+          _parameters = defaultParameters(_action, _sigNonce, _time)
           _pathURL = defaultAliyunUri(_action, _sigNonce, _time)
 
           _parameters['InstanceId'] = server_id

--- a/lib/fog/aliyun/requests/compute/release_eip_address.rb
+++ b/lib/fog/aliyun/requests/compute/release_eip_address.rb
@@ -10,7 +10,7 @@ module Fog
           _sigNonce = randonStr
           _time = Time.new.utc
 
-          _parameters = defalutParameters(_action, _sigNonce, _time)
+          _parameters = defaultParameters(_action, _sigNonce, _time)
           _pathURL = defaultAliyunUri(_action, _sigNonce, _time)
 
           _parameters['AllocationId'] = allocationId

--- a/lib/fog/aliyun/requests/compute/start_server.rb
+++ b/lib/fog/aliyun/requests/compute/start_server.rb
@@ -16,7 +16,7 @@ module Fog
           _sigNonce = randonStr
           _time = Time.new.utc
 
-          _parameters = defalutParameters(_action, _sigNonce, _time)
+          _parameters = defaultParameters(_action, _sigNonce, _time)
           _pathURL = defaultAliyunUri(_action, _sigNonce, _time)
 
           _parameters['InstanceId'] = server_id

--- a/lib/fog/aliyun/requests/compute/stop_server.rb
+++ b/lib/fog/aliyun/requests/compute/stop_server.rb
@@ -16,7 +16,7 @@ module Fog
           _sigNonce = randonStr
           _time = Time.new.utc
 
-          _parameters = defalutParameters(_action, _sigNonce, _time)
+          _parameters = defaultParameters(_action, _sigNonce, _time)
           _pathURL = defaultAliyunUri(_action, _sigNonce, _time)
 
           _parameters['InstanceId'] = server_id

--- a/lib/fog/aliyun/requests/compute/unassociate_eip_address.rb
+++ b/lib/fog/aliyun/requests/compute/unassociate_eip_address.rb
@@ -22,7 +22,7 @@ module Fog
 
           type = options['instance_type']
 
-          _parameters = defalutParameters(_action, _sigNonce, _time)
+          _parameters = defaultParameters(_action, _sigNonce, _time)
           _pathURL = defaultAliyunUri(_action, _sigNonce, _time)
 
           _parameters['InstanceId'] = server_id


### PR DESCRIPTION
The defaultParameters has incorrect spelling and it is being used everywhere with name defalutParameters fixed this in all occurrences. 