### PR TITLE
add vswitch_id,key_pair_name and user_data params to server model

### DIFF
--- a/lib/fog/aliyun/models/compute/server.rb
+++ b/lib/fog/aliyun/models/compute/server.rb
@@ -34,6 +34,7 @@ module Fog
         attribute :charge_type, aliases: 'InstanceChargeType'
         attribute :operation_locks, aliases: 'OperationLocks'
         attribute :expired_at, aliases: 'ExpiredTime'
+        attribute :vswitch_id, aliases: 'VSwitchId'
 
         def image
           requires :image_id

--- a/lib/fog/aliyun/models/compute/server.rb
+++ b/lib/fog/aliyun/models/compute/server.rb
@@ -48,6 +48,15 @@ module Fog
           $vpc = Fog::Compute::Aliyun::Vpcs.new(service: service).all('vpcId' => vpc_id)[0]
         end
 
+        def save(options = {})
+          requires :image_id, :security_group_ids, :type
+          options[:VSwitchId] = vswitch_id if vswitch_id
+          options[:KeyPairName] = key_pair_name if key_pair_name
+          options[:UserData] = user_data if user_data
+          options[:InstanceName] = name if name
+          data = Fog::JSON.decode(service.create_server(image_id, security_group_ids, type, options).body)
+          merge_attributes(data)
+        end
         # {"ImageId"=>"ubuntu1404_32_20G_aliaegis_20150325.vhd", "InnerIpAddress"=>{"IpAddress"=>["10.171.90.171"]},
         #  "VlanId"=>"", "InstanceId"=>"i-25d1ry3jz",
         # "EipAddress"=>{"IpAddress"=>"", "AllocationId"=>"", "InternetChargeType"=>""},

--- a/lib/fog/aliyun/models/compute/server.rb
+++ b/lib/fog/aliyun/models/compute/server.rb
@@ -35,6 +35,7 @@ module Fog
         attribute :operation_locks, aliases: 'OperationLocks'
         attribute :expired_at, aliases: 'ExpiredTime'
         attribute :vswitch_id, aliases: 'VSwitchId'
+        attribute :key_pair_name, aliases: 'KeyPairName'
 
         def image
           requires :image_id

--- a/lib/fog/aliyun/models/compute/server.rb
+++ b/lib/fog/aliyun/models/compute/server.rb
@@ -36,6 +36,7 @@ module Fog
         attribute :expired_at, aliases: 'ExpiredTime'
         attribute :vswitch_id, aliases: 'VSwitchId'
         attribute :key_pair_name, aliases: 'KeyPairName'
+        attribute :user_data, aliases: 'UserData'
 
         def image
           requires :image_id

--- a/lib/fog/aliyun/requests/compute/create_server.rb
+++ b/lib/fog/aliyun/requests/compute/create_server.rb
@@ -83,6 +83,12 @@ module Fog
             end
           end
 
+          _KeyPairName = options[:KeyPairName]
+          if _KeyPairName
+            _parameters['KeyPairName'] = _KeyPairName
+            _pathURL += '&KeyPairName=' + _KeyPairName
+          end
+
           _signature = sign(@aliyun_accesskey_secret, _parameters)
           _pathURL += '&Signature=' + _signature
 

--- a/lib/fog/aliyun/requests/compute/create_server.rb
+++ b/lib/fog/aliyun/requests/compute/create_server.rb
@@ -89,6 +89,12 @@ module Fog
             _pathURL += '&KeyPairName=' + _KeyPairName
           end
 
+          _UserData = options[:UserData]
+          if _UserData
+            _parameters['UserData'] = _UserData
+            _pathURL += '&UserData=' + _UserData
+          end
+
           _signature = sign(@aliyun_accesskey_secret, _parameters)
           _pathURL += '&Signature=' + _signature
 


### PR DESCRIPTION
This PR adds vswitch_id, key_pair_name and user_data attributes to sever model. The support for key_pair_name is also added in create_server request.