### PR TITLE
Add KeyPairName attribute in server

### DIFF
--- a/lib/fog/aliyun/models/compute/server.rb
+++ b/lib/fog/aliyun/models/compute/server.rb
@@ -34,6 +34,7 @@ module Fog
         attribute :charge_type, aliases: 'InstanceChargeType'
         attribute :operation_locks, aliases: 'OperationLocks'
         attribute :expired_at, aliases: 'ExpiredTime'
+        attribute :key_pair_name, aliases: 'KeyPairName'
 
         def image
           requires :image_id

--- a/lib/fog/aliyun/requests/compute/create_server.rb
+++ b/lib/fog/aliyun/requests/compute/create_server.rb
@@ -83,6 +83,12 @@ module Fog
             end
           end
 
+          _KeyPairName = options[:KeyPairName]
+          if _KeyPairName
+            _parameters['KeyPairName'] = _KeyPairName
+            _pathURL += '&KeyPairName=' + _KeyPairName
+          end
+
           _signature = sign(@aliyun_accesskey_secret, _parameters)
           _pathURL += '&Signature=' + _signature
 


### PR DESCRIPTION
The KeyPairName parameter is missing for the server model. This PR adds it in model and in create_server request.