### PR TITLE
remove :aliyun_zone_id validatation

### DIFF
--- a/lib/fog/aliyun/compute.rb
+++ b/lib/fog/aliyun/compute.rb
@@ -271,7 +271,6 @@ module Fog
           missing_credentials << :aliyun_accesskey_secret unless @aliyun_accesskey_secret
           missing_credentials << :aliyun_region_id unless @aliyun_region_id
           missing_credentials << :aliyun_url unless @aliyun_url
-          missing_credentials << :aliyun_zone_id unless @aliyun_zone_id
           raise ArgumentError, "Missing required arguments: #{missing_credentials.join(', ')}" unless missing_credentials.empty?
 
           @connection_options = options[:connection_options] || {}


### PR DESCRIPTION
This removes the validation of :aliyun_zone_id in Compute. 

1. If I see zone_id is not mandatory to create connection,
https://www.alibabacloud.com/help/doc-detail/102988.htm?spm=a2c63.p38356.b99.421.41a2466at0ZKvz

2. There are two requests which are using this parameter and what I think is zone_id can be provided with options hash or if mandatory then separetely for this two calls,

create_disk.rb
create_vswitch.rb

With this if its mandatory then validations should be in respective models like vswitch and disk instead at creating connection.