### PR TITLE
correct internet bandwidth params assignment

### DIFF
--- a/lib/fog/aliyun/requests/compute/create_server.rb
+++ b/lib/fog/aliyun/requests/compute/create_server.rb
@@ -68,19 +68,18 @@ module Fog
               _parameters['PrivateIpAddress'] = _PrivateIpAddress
               _pathURL += '&PrivateIpAddress=' + _PrivateIpAddress
             end
-          else
+          end
 
-            _InternetMaxBandwidthIn = options[:InternetMaxBandwidthIn]
-            if _InternetMaxBandwidthIn
-              _parameters['InternetMaxBandwidthIn'] = _InternetMaxBandwidthIn
-              _pathURL += '&InternetMaxBandwidthIn=' + _InternetMaxBandwidthIn
-            end
+          _InternetMaxBandwidthIn = options[:InternetMaxBandwidthIn]
+          if _InternetMaxBandwidthIn
+            _parameters['InternetMaxBandwidthIn'] = _InternetMaxBandwidthIn
+            _pathURL += '&InternetMaxBandwidthIn=' + _InternetMaxBandwidthIn
+          end
 
-            _InternetMaxBandwidthOut = options[:InternetMaxBandwidthOut]
-            if _InternetMaxBandwidthOut
-              _parameters['InternetMaxBandwidthOut'] = _InternetMaxBandwidthOut
-              _pathURL += '&InternetMaxBandwidthOut=' + _InternetMaxBandwidthOut
-            end
+          _InternetMaxBandwidthOut = options[:InternetMaxBandwidthOut]
+          if _InternetMaxBandwidthOut
+            _parameters['InternetMaxBandwidthOut'] = _InternetMaxBandwidthOut
+            _pathURL += '&InternetMaxBandwidthOut=' + _InternetMaxBandwidthOut
           end
 
           _signature = sign(@aliyun_accesskey_secret, _parameters)


### PR DESCRIPTION
The InternetMaxBandwidthOut and InternetMaxBandwidthIn can be set even when having VPC for system. The InternetMaxBandwidthOut is required to be set greater than 0 to get the public IpAddress and public ipaddress allocation does not depend if system has vswitch/vpc. So taking these two parameters out of the vswitch_id condition.