### PR TITLE
Add allocate_public_ip_address in compute

### DIFF
--- a/lib/fog/aliyun/compute.rb
+++ b/lib/fog/aliyun/compute.rb
@@ -117,6 +117,9 @@ module Fog
       request :attach_disk
       request :detach_disk
 
+      # PublicIpAddress
+      request :allocate_public_ip_address
+
       class Mock
         attr_reader :auth_token
         attr_reader :auth_token_expiration


### PR DESCRIPTION
The allocate_public_ip_address request is missing in compute, this adds it to avoid 'undefined method' errors when called using service.