### PR TITLE
fix issue 30,fully support vpc endpoint

### DIFF
--- a/lib/fog/aliyun/requests/storage/copy_object.rb
+++ b/lib/fog/aliyun/requests/storage/copy_object.rb
@@ -19,8 +19,10 @@ module Fog
           source_bucket ||= bucket
           target_bucket ||= bucket
           headers = { 'x-oss-copy-source' => "/#{source_bucket}/#{source_object}" }
-          location = get_bucket_location(target_bucket)
-          endpoint = 'http://' + location + '.aliyuncs.com'
+          endpoint = options[:endpoint]
+          if endpoint.nil?
+            endpoint = get_bucket_endpoint(bucket)
+          end
           resource = target_bucket + '/' + target_object
           request(expects: [200, 203],
                   headers: headers,

--- a/lib/fog/aliyun/requests/storage/delete_bucket.rb
+++ b/lib/fog/aliyun/requests/storage/delete_bucket.rb
@@ -10,8 +10,7 @@ module Fog
         # * bucket<~String> - Name of bucket to delete
         #
         def delete_bucket(bucket)
-          location = get_bucket_location(bucket)
-          endpoint = 'http://' + location + '.aliyuncs.com'
+          endpoint = get_bucket_endpoint(bucket)
           resource = bucket + '/'
           request(
             expects: 204,

--- a/lib/fog/aliyun/requests/storage/delete_container.rb
+++ b/lib/fog/aliyun/requests/storage/delete_container.rb
@@ -13,8 +13,10 @@ module Fog
         def delete_container(container, options = {})
           bucket = options[:bucket]
           bucket ||= @aliyun_oss_bucket
-          location = get_bucket_location(bucket)
-          endpoint = 'http://' + location + '.aliyuncs.com'
+          endpoint = options[:endpoint]
+          if endpoint.nil?
+            endpoint = get_bucket_endpoint(bucket)
+          end
           object = container + '/'
           resource = bucket + '/' + object
 

--- a/lib/fog/aliyun/requests/storage/delete_object.rb
+++ b/lib/fog/aliyun/requests/storage/delete_object.rb
@@ -12,8 +12,10 @@ module Fog
         def delete_object(object, options = {})
           bucket = options[:bucket]
           bucket ||= @aliyun_oss_bucket
-          location = get_bucket_location(bucket)
-          endpoint = 'http://' + location + '.aliyuncs.com'
+          endpoint = options[:endpoint]
+          if endpoint.nil?
+            endpoint = get_bucket_endpoint(bucket)
+          end
           resource = bucket + '/' + object
           request(
             expects: 204,
@@ -27,8 +29,7 @@ module Fog
 
         def abort_multipart_upload(bucket, object, endpoint, uploadid)
           if endpoint.nil?
-            location = get_bucket_location(bucket)
-            endpoint = 'http://' + location + '.aliyuncs.com'
+            endpoint = get_bucket_endpoint(bucket)
           end
           path = object + '?uploadId=' + uploadid
           resource = bucket + '/' + path

--- a/lib/fog/aliyun/requests/storage/get_bucket.rb
+++ b/lib/fog/aliyun/requests/storage/get_bucket.rb
@@ -5,8 +5,7 @@ module Fog
     class Aliyun
       class Real
         def get_bucket(bucket)
-          location = get_bucket_location(bucket)
-          endpoint = 'http://' + location + '.aliyuncs.com'
+          endpoint = get_bucket_endpoint(bucket)
           resource = bucket + '/'
           ret = request(
             expects: [200, 203],
@@ -17,6 +16,18 @@ module Fog
           )
           xml = ret.data[:body]
           XmlSimple.xml_in(xml)
+        end
+
+        def get_bucket_endpoint(bucket)
+          location = get_bucket_location(bucket)
+          # If the endpoint specified contains with -internal, then assume it is a vpc endpoint, 
+          # hence, the bucket endpoint returned is also internal one...
+          # Otherwise, continue to use the public endpoint as previous edition.
+          if @aliyun_oss_endpoint.downcase()['-internal']
+            endpoint = 'http://' + location + '-internal'+'.aliyuncs.com'
+          else
+            endpoint = 'http://' + location +'.aliyuncs.com'
+          end     
         end
 
         def get_bucket_location(bucket)
@@ -33,8 +44,7 @@ module Fog
         end
 
         def get_bucket_acl(bucket)
-          location = get_bucket_location(bucket)
-          endpoint = 'http://' + location + '.aliyuncs.com'
+          endpoint = get_bucket_endpoint(bucket)
           attribute = '?acl'
           resource = bucket + '/' + attribute
           ret = request(
@@ -49,8 +59,7 @@ module Fog
         end
 
         def get_bucket_CORSRules(bucket)
-          location = get_bucket_location(bucket)
-          endpoint = 'http://' + location + '.aliyuncs.com'
+          endpoint = get_bucket_endpoint(bucket)
           attribute = '?cors'
           resource = bucket + '/' + attribute
           ret = request(
@@ -65,8 +74,7 @@ module Fog
         end
 
         def get_bucket_lifecycle(bucket)
-          location = get_bucket_location(bucket)
-          endpoint = 'http://' + location + '.aliyuncs.com'
+          endpoint = get_bucket_endpoint(bucket)
           attribute = '?lifecycle'
           resource = bucket + '/' + attribute
           ret = request(
@@ -81,8 +89,7 @@ module Fog
         end
 
         def get_bucket_logging(bucket)
-          location = get_bucket_location(bucket)
-          endpoint = 'http://' + location + '.aliyuncs.com'
+          endpoint = get_bucket_endpoint(bucket)
           attribute = '?logging'
           resource = bucket + '/' + attribute
           ret = request(
@@ -97,8 +104,7 @@ module Fog
         end
 
         def get_bucket_referer(bucket)
-          location = get_bucket_location(bucket)
-          endpoint = 'http://' + location + '.aliyuncs.com'
+          endpoint = get_bucket_endpoint(bucket)
           attribute = '?referer'
           resource = bucket + '/' + attribute
           ret = request(
@@ -113,8 +119,7 @@ module Fog
         end
 
         def get_bucket_website(bucket)
-          location = get_bucket_location(bucket)
-          endpoint = 'http://' + location + '.aliyuncs.com'
+          endpoint = get_bucket_endpoint(bucket)
           attribute = '?website'
           resource = bucket + '/' + attribute
           ret = request(

--- a/lib/fog/aliyun/requests/storage/get_container.rb
+++ b/lib/fog/aliyun/requests/storage/get_container.rb
@@ -38,7 +38,7 @@ module Fog
             path += '?delimiter=' + delimiter
           end
 
-          location = get_bucket_location(bucket)
+          # location = get_bucket_location(bucket)
           resource = bucket + '/'
           ret = request(
             expects: [200, 203, 400],

--- a/lib/fog/aliyun/requests/storage/get_containers.rb
+++ b/lib/fog/aliyun/requests/storage/get_containers.rb
@@ -42,7 +42,7 @@ module Fog
             path += '?delimiter=' + delimiter
           end
 
-          location = get_bucket_location(bucket)
+          # location = get_bucket_location(bucket)
           resource = bucket + '/'
           ret = request(
             expects: [200, 203, 400],

--- a/lib/fog/aliyun/requests/storage/get_object.rb
+++ b/lib/fog/aliyun/requests/storage/get_object.rb
@@ -15,8 +15,7 @@ module Fog
           bucket ||= @aliyun_oss_bucket
           endpoint = options[:endpoint]
           if endpoint.nil?
-            location = get_bucket_location(bucket)
-            endpoint = 'http://' + location + '.aliyuncs.com'
+            endpoint = get_bucket_endpoint(bucket)
           end
           resource = bucket + '/' + object
           para = {

--- a/lib/fog/aliyun/requests/storage/get_object_http_url.rb
+++ b/lib/fog/aliyun/requests/storage/get_object_http_url.rb
@@ -21,6 +21,10 @@ module Fog
           acl = get_bucket_acl(bucket)
           location = get_bucket_location(bucket)
 
+          if @aliyun_oss_endpoint.downcase()['-internal']
+            location =   location + '-internal' 
+          end     
+
           if acl == 'private'
             expires_time = (Time.now.to_i + (expires.nil? ? 0 : expires.to_i)).to_s
             resource = bucket + '/' + object

--- a/lib/fog/aliyun/requests/storage/get_object_https_url.rb
+++ b/lib/fog/aliyun/requests/storage/get_object_https_url.rb
@@ -21,6 +21,10 @@ module Fog
           acl = get_bucket_acl(bucket)
           location = get_bucket_location(bucket)
 
+          if @aliyun_oss_endpoint.downcase()['-internal']
+            location =   location + '-internal' 
+          end     
+
           if acl == 'private'
             expires_time = (Time.now.to_i + (expires.nil? ? 0 : expires.to_i)).to_s
             resource = bucket + '/' + object

--- a/lib/fog/aliyun/requests/storage/head_object.rb
+++ b/lib/fog/aliyun/requests/storage/head_object.rb
@@ -12,8 +12,10 @@ module Fog
         def head_object(object, options = {})
           bucket = options[:bucket]
           bucket ||= @aliyun_oss_bucket
-          location = get_bucket_location(bucket)
-          endpoint = 'http://' + location + '.aliyuncs.com'
+          endpoint = options[:endpoint]
+          if endpoint.nil?
+            endpoint = get_bucket_endpoint(bucket)
+          end
           resource = bucket + '/' + object
           ret = request(
             expects: [200, 404],

--- a/lib/fog/aliyun/requests/storage/list_objects.rb
+++ b/lib/fog/aliyun/requests/storage/list_objects.rb
@@ -45,8 +45,7 @@ module Fog
 
         def list_multipart_uploads(bucket, endpoint, _options = {})
           if endpoint.nil?
-            location = get_bucket_location(bucket)
-            endpoint = 'http://' + location + '.aliyuncs.com'
+            endpoint = get_bucket_endpoint(bucket)
           end
           path = '?uploads'
           resource = bucket + '/' + path
@@ -64,8 +63,7 @@ module Fog
 
         def list_parts(bucket, object, endpoint, uploadid, _options = {})
           if endpoint.nil?
-            location = get_bucket_location(bucket)
-            endpoint = 'http://' + location + '.aliyuncs.com'
+            endpoint = get_bucket_endpoint(bucket)
           end
           path = object + '?uploadId=' + uploadid
           resource = bucket + '/' + path

--- a/lib/fog/aliyun/requests/storage/put_container.rb
+++ b/lib/fog/aliyun/requests/storage/put_container.rb
@@ -12,8 +12,10 @@ module Fog
         def put_container(name, options = {})
           bucket = options[:bucket]
           bucket ||= @aliyun_oss_bucket
-          location = get_bucket_location(bucket)
-          endpoint = 'http://' + location + '.aliyuncs.com'
+          endpoint = options[:endpoint]
+          if endpoint.nil?
+            endpoint = get_bucket_endpoint(bucket)
+          end
 
           path = name + '/'
           resource = bucket + '/' + name + '/'

--- a/lib/fog/aliyun/requests/storage/put_object.rb
+++ b/lib/fog/aliyun/requests/storage/put_object.rb
@@ -12,8 +12,10 @@ module Fog
         def put_object(object, file = nil, options = {})
           bucket = options[:bucket]
           bucket ||= @aliyun_oss_bucket
-          location = get_bucket_location(bucket)
-          endpoint = 'http://' + location + '.aliyuncs.com'
+          endpoint = options[:endpoint]
+          if endpoint.nil?
+            endpoint = get_bucket_endpoint(bucket)
+          end
           return put_folder(bucket, object, endpoint) if file.nil?
 
           # put multiparts if object's size is over 100m
@@ -36,8 +38,10 @@ module Fog
         def put_object_with_body(object, body, options = {})
           bucket = options[:bucket]
           bucket ||= @aliyun_oss_bucket
-          location = get_bucket_location(bucket)
-          endpoint = 'http://' + location + '.aliyuncs.com'
+          endpoint = options[:endpoint]
+          if endpoint.nil?
+            endpoint = get_bucket_endpoint(bucket)
+          end
 
           resource = bucket + '/' + object
           request(
@@ -53,8 +57,7 @@ module Fog
 
         def put_folder(bucket, folder, endpoint)
           if endpoint.nil?
-            location = get_bucket_location(bucket)
-            endpoint = 'http://' + location + '.aliyuncs.com'
+            endpoint = get_bucket_endpoint(bucket)
           end
           path = folder + '/'
           resource = bucket + '/' + folder + '/'
@@ -69,8 +72,7 @@ module Fog
         end
 
         def put_multipart_object(bucket, object, file)
-          location = get_bucket_location(bucket)
-          endpoint = 'http://' + location + '.aliyuncs.com'
+          endpoint = get_bucket_endpoint(bucket)
 
           # find the right uploadid
           uploads = list_multipart_uploads(bucket, endpoint)
@@ -113,8 +115,7 @@ module Fog
 
         def initiate_multipart_upload(bucket, object, endpoint)
           if endpoint.nil?
-            location = get_bucket_location(bucket)
-            endpoint = 'http://' + location + '.aliyuncs.com'
+            endpoint = get_bucket_endpoint(bucket)
           end
           path = object + '?uploads'
           resource = bucket + '/' + path
@@ -131,8 +132,7 @@ module Fog
 
         def upload_part(bucket, object, endpoint, partNumber, uploadId, body)
           if endpoint.nil?
-            location = get_bucket_location(bucket)
-            endpoint = 'http://' + location + '.aliyuncs.com'
+            endpoint = get_bucket_endpoint(bucket)
           end
           path = object + '?partNumber=' + partNumber + '&uploadId=' + uploadId
           resource = bucket + '/' + path
@@ -149,8 +149,7 @@ module Fog
 
         def complete_multipart_upload(bucket, object, endpoint, uploadId)
           if endpoint.nil?
-            location = get_bucket_location(bucket)
-            endpoint = 'http://' + location + '.aliyuncs.com'
+            endpoint = get_bucket_endpoint(bucket)
           end
           parts = list_parts(bucket, object, endpoint, uploadId, options = {})
           request_part = []


### PR DESCRIPTION
Please refer to https://github.com/fog/fog-aliyun/issues/30. In the current version, some of the storage API will compose the OSS endpoint to public endpoint even the user actually want to use VPC endpoint.
The fix is simple by assuming that if the connection endpoint contains '-internal', then it must be endpoint, then the implementation can compose the right endpoint.