### PR TITLE
fix not found error when getting an object

### DIFF
--- a/lib/fog/aliyun/models/storage/files.rb
+++ b/lib/fog/aliyun/models/storage/files.rb
@@ -68,7 +68,7 @@ module Fog
             data = service.get_object(object)
           rescue StandardError => error
             case error.response.body
-            when %r{<Code>NoSuchKey</Code>}
+            when %r{<Code>NoSuchKey</Code>},%r{<Code>SymlinkTargetNotExist</Code>}
               nil
             else
               raise(error)


### PR DESCRIPTION
If an object does not exist, the get_object will return 404 error. The 404 error has two error code: "NoSuchKey" and "SymlinkTargetNotExist".