### PR TITLE
Add preemptive instance request fields to server

### DIFF
--- a/fog-aliyun.gemspec
+++ b/fog-aliyun.gemspec
@@ -7,7 +7,7 @@ require 'fog/aliyun/version'
 Gem::Specification.new do |spec|
   spec.name = 'fog-aliyun'
   spec.version = Fog::Aliyun::VERSION
-  spec.authors = ['Qinsi Deng, Jianxun Li, Jane Han']
+  spec.authors = ['Qinsi Deng, Jianxun Li, Jane Han, Ricky Smith']
   spec.email = ['dengqinsi@sina.com']
 
   spec.summary = 'Fog provider for Aliyun Web Services.'

--- a/lib/fog/aliyun/compute.rb
+++ b/lib/fog/aliyun/compute.rb
@@ -303,13 +303,18 @@ module Fog
 
         def request(params)
           begin
-            response = @connection.request(params.merge(headers: {
+            headers = {
               'Content-Type' => 'application/json',
               'Accept' => 'application/json',
               'X-Auth-Token' => @auth_token
-            }.merge!(params[:headers] || {}),
-                                                        path: "#{@path}/#{params[:path]}",
-                                                        query: params[:query]))
+            }.merge!(params[:headers] || {})
+
+            request_params = params.merge(
+              headers: headers,
+              path: "#{@path}/#{params[:path]}",
+              query: params[:query])
+
+            response = @connection.request(request_params)
           rescue Excon::Errors::HTTPStatusError => error
             raise case error
                   when Excon::Errors::NotFound
@@ -319,7 +324,7 @@ module Fog
                   end
           end
 
-          response.body = Fog::JSON.decode(response.body) if !response.body.empty? && response.get_header('Content-Type') == 'application/json'
+          response.body = Fog::JSON.decode(response.body) if !response.body.empty? && response.get_header('Content-Type').start_with?('application/json')
 
           response
         end
@@ -342,7 +347,7 @@ module Fog
                   end
           end
 
-          response.body = Fog::JSON.decode(response.body) if !response.body.empty? && response.get_header('Content-Type') == 'application/json'
+          response.body = Fog::JSON.decode(response.body) if !response.body.empty? && response.get_header('Content-Type').start_with?('application/json')
 
           response
         end

--- a/lib/fog/aliyun/models/compute/eip_address.rb
+++ b/lib/fog/aliyun/models/compute/eip_address.rb
@@ -33,7 +33,7 @@ module Fog
           options[:bandwidth] = bandwidth if bandwidth
           options[:internet_charge_type] = charge_type if charge_type
 
-          data = Fog::JSON.decode(service.allocate_eip_address(options).body)
+          data = service.allocate_eip_address(options).body
           merge_attributes(data)
           true
         end

--- a/lib/fog/aliyun/models/compute/eip_addresses.rb
+++ b/lib/fog/aliyun/models/compute/eip_addresses.rb
@@ -10,7 +10,7 @@ module Fog
         model Fog::Compute::Aliyun::EipAddress
 
         def all(filters_arg = {})
-          data = Fog::JSON.decode(service.list_eip_addresses(filters_arg).body)['EipAddresses']['EipAddress']
+          data = service.list_eip_addresses(filters_arg).body['EipAddresses']['EipAddress']
           load(data)
           # load(data['volumeSet'])
           # if server

--- a/lib/fog/aliyun/models/compute/image.rb
+++ b/lib/fog/aliyun/models/compute/image.rb
@@ -39,7 +39,7 @@ module Fog
           requires :snapshot_id
           options[:name] = name if name
           options[:description] = description if description
-          data = Fog::JSON.decode(service.create_image(snapshot_id, options).body)
+          data = service.create_image(snapshot_id, options).body
           merge_attributes(data)
           true
         end

--- a/lib/fog/aliyun/models/compute/images.rb
+++ b/lib/fog/aliyun/models/compute/images.rb
@@ -14,7 +14,7 @@ module Fog
             Fog::Logger.deprecation("all with #{filters_arg.class} param is deprecated, use all('diskIds' => []) instead [light_black](#{caller.first})[/]")
             filters_arg = { imageId: filters_arg }
           end
-          data = Fog::JSON.decode(service.list_images(filters_arg).body)['Images']['Image']
+          data = service.list_images(filters_arg).body['Images']['Image']
           load(data)
         end
 

--- a/lib/fog/aliyun/models/compute/route_entrys.rb
+++ b/lib/fog/aliyun/models/compute/route_entrys.rb
@@ -14,7 +14,7 @@ module Fog
         def all(options = {})
           requires :route_table
           options[:routeTableId] = route_table.id
-          data = Fog::JSON.decode(service.list_route_tables(route_table.v_router_id, options).body)['RouteTables']['RouteTable'][0]['RouteEntrys']['RouteEntry']
+          data = service.list_route_tables(route_table.v_router_id, options).body['RouteTables']['RouteTable'][0]['RouteEntrys']['RouteEntry']
           load(data)
         end
 

--- a/lib/fog/aliyun/models/compute/route_tables.rb
+++ b/lib/fog/aliyun/models/compute/route_tables.rb
@@ -13,7 +13,7 @@ module Fog
 
         def all(options = {})
           requires :v_router
-          data = Fog::JSON.decode(service.list_route_tables(v_router.id, options).body)['RouteTables']['RouteTable']
+          data = service.list_route_tables(v_router.id, options).body['RouteTables']['RouteTable']
           load(data)
         end
 

--- a/lib/fog/aliyun/models/compute/security_group.rb
+++ b/lib/fog/aliyun/models/compute/security_group.rb
@@ -26,7 +26,7 @@ module Fog
           options[:vpcId] = vpc_id if vpc_id
           options[:name] = name if name
           options[:description] = description if description
-          Fog::JSON.decode(service.create_security_group(options).body)
+          service.create_security_group(options).body
           true
         end
 

--- a/lib/fog/aliyun/models/compute/security_group_rules.rb
+++ b/lib/fog/aliyun/models/compute/security_group_rules.rb
@@ -11,7 +11,7 @@ module Fog
         attribute :security_group_id
 
         def get(security_group_id, options = {})
-          data = Fog::JSON.decode(service.list_security_group_rules(security_group_id, options).body)
+          data = service.list_security_group_rules(security_group_id, options).body
           self.security_group_id = data['SecurityGroupId']
           permissions = data['Permissions']['Permission']
           permissions.each do |permission|

--- a/lib/fog/aliyun/models/compute/security_groups.rb
+++ b/lib/fog/aliyun/models/compute/security_groups.rb
@@ -10,7 +10,7 @@ module Fog
         model Fog::Compute::Aliyun::SecurityGroup
 
         def all(options = {})
-          data = Fog::JSON.decode(service.list_security_groups(options).body)['SecurityGroups']['SecurityGroup']
+          data = service.list_security_groups(options).body['SecurityGroups']['SecurityGroup']
           load(data)
           # ['Images']['Image']
         end

--- a/lib/fog/aliyun/models/compute/server.rb
+++ b/lib/fog/aliyun/models/compute/server.rb
@@ -34,6 +34,10 @@ module Fog
         attribute :charge_type, aliases: 'InstanceChargeType'
         attribute :operation_locks, aliases: 'OperationLocks'
         attribute :expired_at, aliases: 'ExpiredTime'
+        attribute :spot_strategy, aliases: 'SpotStrategy'
+        attribute :spot_price_limit, aliases: 'SpotPriceLimit'
+        attribute :spot_duration, aliases: 'SpotDuration'
+        attribute :spot_interruption_behavior, aliases: 'SpotInterruptionBehavior'
 
         def image
           requires :image_id

--- a/lib/fog/aliyun/models/compute/servers.rb
+++ b/lib/fog/aliyun/models/compute/servers.rb
@@ -10,8 +10,8 @@ module Fog
         model Fog::Compute::Aliyun::Server
 
         def all(options = {})
-          data = Fog::JSON.decode(service.list_servers(options).body)['Instances']['Instance']
-          load(data)
+          response = service.list_servers(options).body
+          load(response['Instances']['Instance'])
         end
 
         # Creates a new server and populates ssh keys

--- a/lib/fog/aliyun/models/compute/snapshot.rb
+++ b/lib/fog/aliyun/models/compute/snapshot.rb
@@ -33,7 +33,7 @@ module Fog
           requires :volume_id
           options[:name] = name if name
           options[:description] = description if description
-          data = Fog::JSON.decode(service.create_snapshot(volume_id, options).body)
+          data = service.create_snapshot(volume_id, options).body
           merge_attributes(data)
           true
         end

--- a/lib/fog/aliyun/models/compute/snapshots.rb
+++ b/lib/fog/aliyun/models/compute/snapshots.rb
@@ -24,7 +24,7 @@ module Fog
           volume_type = filters_arg[:volume_type]
           filters_arg[:diskId] = volume_id if volume_id
           filters_arg[:sourseDiskType] = volume_type if volume_type
-          data = Fog::JSON.decode(service.list_snapshots(filters_arg).body)['Snapshots']['Snapshot']
+          data = service.list_snapshots(filters_arg).body['Snapshots']['Snapshot']
           load(data)
         end
 

--- a/lib/fog/aliyun/models/compute/volume.rb
+++ b/lib/fog/aliyun/models/compute/volume.rb
@@ -63,10 +63,10 @@ module Fog
           options[:name] = name if name
           options[:description] = description if description
           if snapshot_id
-            data = Fog::JSON.decode(service.create_disk_by_snapshot(snapshot_id, options).body)
+            data = service.create_disk_by_snapshot(snapshot_id, options).body
             merge_attributes(data)
           elsif size
-            data = Fog::JSON.decode(service.create_disk(size, options).body)
+            data = service.create_disk(size, options).body
             merge_attributes(data)
           end
 

--- a/lib/fog/aliyun/models/compute/volumes.rb
+++ b/lib/fog/aliyun/models/compute/volumes.rb
@@ -78,7 +78,7 @@ module Fog
             Fog::Logger.deprecation("all with #{filters_arg.class} param is deprecated, use all('diskIds' => []) instead [light_black](#{caller.first})[/]")
             filters_arg = { 'diskIds' => [*filters_arg] }
           end
-          data = Fog::JSON.decode(service.list_disks(filters_arg).body)['Disks']['Disk']
+          data = service.list_disks(filters_arg).body['Disks']['Disk']
           load(data)
           # load(data['volumeSet'])
           # if server

--- a/lib/fog/aliyun/models/compute/vpc.rb
+++ b/lib/fog/aliyun/models/compute/vpc.rb
@@ -70,7 +70,7 @@ module Fog
           requires :cidr_block
           options[:name] = name if name
           options[:description] = description if description
-          Fog::JSON.decode(service.create_vpc(cidr_block, options).body)
+          service.create_vpc(cidr_block, options).body
           true
         end
       end

--- a/lib/fog/aliyun/models/compute/vpcs.rb
+++ b/lib/fog/aliyun/models/compute/vpcs.rb
@@ -52,7 +52,7 @@ module Fog
             Fog::Logger.warning("all with #{filters_arg.class} param is deprecated, use all('vpcId' => []) instead [light_black](#{caller.first})[/]")
             filters_arg = { 'vpcId' => [*filters_arg] }
           end
-          data = Fog::JSON.decode(service.list_vpcs(filters_arg).body)['Vpcs']['Vpc']
+          data = service.list_vpcs(filters_arg).body['Vpcs']['Vpc']
           load(data)
         end
 

--- a/lib/fog/aliyun/models/compute/vrouters.rb
+++ b/lib/fog/aliyun/models/compute/vrouters.rb
@@ -33,7 +33,7 @@ module Fog
             Fog::Logger.warning("all with #{filters_arg.class} param is deprecated, use all('vRouterId' => "") instead [light_black](#{caller.first})[/]")
             filters_arg = { 'vRouterId' => filters_arg }
           end
-          data = Fog::JSON.decode(service.list_vrouters(filters_arg).body)['VRouters']['VRouter']
+          data = service.list_vrouters(filters_arg).body['VRouters']['VRouter']
           load(data)
         end
 

--- a/lib/fog/aliyun/models/compute/vswitch.rb
+++ b/lib/fog/aliyun/models/compute/vswitch.rb
@@ -55,7 +55,7 @@ module Fog
           requires :vpc, :cidr_block
           options[:name] = name if name
           options[:description] = description if description
-          Fog::JSON.decode(service.create_vswitch(vpc.id, cidr_block, options).body)
+          service.create_vswitch(vpc.id, cidr_block, options).body
           true
         end
 
@@ -64,7 +64,7 @@ module Fog
         end
 
         def all
-          Fog::JSON.decode(service.list_vswitchs(vpc_id).body)['VSwitches']['VSwitch']
+          service.list_vswitchs(vpc_id).body['VSwitches']['VSwitch']
         end
       end
     end

--- a/lib/fog/aliyun/models/compute/vswitches.rb
+++ b/lib/fog/aliyun/models/compute/vswitches.rb
@@ -51,7 +51,7 @@ module Fog
 
         def all(options = {})
           requires :vpc
-          data = Fog::JSON.decode(service.list_vswitchs(vpc.id, options).body)['VSwitches']['VSwitch']
+          data = service.list_vswitchs(vpc.id, options).body['VSwitches']['VSwitch']
           load(data)
         end
 

--- a/lib/fog/aliyun/requests/compute/create_server.rb
+++ b/lib/fog/aliyun/requests/compute/create_server.rb
@@ -11,80 +11,83 @@ module Fog
           _time = Time.new.utc
 
           _parameters = defalutParameters(_action, _sigNonce, _time)
-          _pathURL = defaultAliyunUri(_action, _sigNonce, _time)
-
           _parameters['ImageId'] = imageId
-          _pathURL += '&ImageId=' + imageId
-
           _parameters['InstanceType'] = instanceType
-          _pathURL += '&InstanceType=' + instanceType
-
           _parameters['SecurityGroupId'] = securityGroupId
-          _pathURL += '&SecurityGroupId=' + securityGroupId
 
           _ZoneId = options[:ZoneId]
           if _ZoneId
             _parameters['ZoneId'] = _ZoneId
-            _pathURL += '&ZoneId=' + _ZoneId
           end
 
           _InstanceName = options[:InstanceName]
           if _InstanceName
             _parameters['InstanceName'] = _InstanceName
-            _pathURL += '&InstanceName=' + _InstanceName
           end
 
           _Description = options[:Description]
           if _Description
             _parameters['Description'] = _Description
-            _pathURL += '&Description=' + _Description
           end
 
           _InternetChargeType = options[:InternetChargeType]
           if _InternetChargeType
             _parameters['InternetChargeType'] = _InternetChargeType
-            _pathURL += '&InternetChargeType=' + _InternetChargeType
           end
 
           _HostName = options[:HostName]
           if _HostName
             _parameters['HostName'] = _HostName
-            _pathURL += '&HostName=' + _HostName
           end
 
           _Password = options[:Password]
           if _Password
             _parameters['Password'] = _Password
-            _pathURL += '&Password=' + _Password
+          end
+
+          _SpotStrategy = options[:SpotStrategy]
+          if _SpotStrategy
+            _parameters['SpotStrategy'] = _SpotStrategy
+          end
+
+          _SpotPriceLimit = options[:SpotPriceLimit]
+          if _SpotPriceLimit
+            _parameters['SpotPriceLimit'] = _SpotPriceLimit
+          end
+
+          _SpotDuration = options[:SpotDuration]
+          if _SpotDuration
+            _parameters['SpotDuration'] = _SpotDuration
+          end
+
+          _SpotInterruptionBehavior = options[:SpotInterruptionBehavior]
+          if _SpotInterruptionBehavior
+            _parameters['SpotInterruptionBehavior'] = _SpotInterruptionBehavior
           end
 
           _VSwitchId = options[:VSwitchId]
           _PrivateIpAddress = options[:PrivateIpAddress]
           if _VSwitchId
             _parameters['VSwitchId'] = _VSwitchId
-            _pathURL += '&VSwitchId=' + _VSwitchId
 
             if _PrivateIpAddress
               _parameters['PrivateIpAddress'] = _PrivateIpAddress
-              _pathURL += '&PrivateIpAddress=' + _PrivateIpAddress
             end
           else
 
             _InternetMaxBandwidthIn = options[:InternetMaxBandwidthIn]
             if _InternetMaxBandwidthIn
               _parameters['InternetMaxBandwidthIn'] = _InternetMaxBandwidthIn
-              _pathURL += '&InternetMaxBandwidthIn=' + _InternetMaxBandwidthIn
             end
 
             _InternetMaxBandwidthOut = options[:InternetMaxBandwidthOut]
             if _InternetMaxBandwidthOut
               _parameters['InternetMaxBandwidthOut'] = _InternetMaxBandwidthOut
-              _pathURL += '&InternetMaxBandwidthOut=' + _InternetMaxBandwidthOut
             end
           end
 
           _signature = sign(@aliyun_accesskey_secret, _parameters)
-          _pathURL += '&Signature=' + _signature
+          _pathURL = defaultAliyunUri(_action, _sigNonce, _time) + '&' + _parameters.merge({Signature: _signature}).map{|k,v| "#{k}=#{v}" }.join('&')
 
           request(
             expects: [200, 203],


### PR DESCRIPTION
In addition to adding the preemptive instance fields (aka spot instance), I simplified the url/parameter building a little bit to make it easier to read/expand.

There was also a bug detecting the content type. Fixing that allowed the fog-core library to automatically deserialize some responses, so we don't have to explicitly decode responses here anymore.

Also, claiming a little credit for myself for bragging rights.