### PR TITLE
using oss ruby sdk to improve downloading object performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ tmp
 mkmf.log
 gemfiles/*.lock
 morethan100m
+*.log

--- a/fog-aliyun.gemspec
+++ b/fog-aliyun.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'memory_profiler'
+  spec.add_development_dependency 'aliyun-sdk'
 
   spec.add_dependency 'fog-core'
   spec.add_dependency 'fog-json'

--- a/lib/fog/aliyun/storage.rb
+++ b/lib/fog/aliyun/storage.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 require 'xmlsimple'
+require 'aliyun/oss'
+
+# Using Aliyun OSS Ruby SDK
+AliyunOssSdk= Aliyun::OSS
 
 module Fog
   module Aliyun
@@ -97,6 +101,11 @@ module Fog
           @port = uri.port || DEFAULT_SCHEME_PORT[@scheme]
 
           @persistent = options[:persistent] || false
+          @oss_client = AliyunOssSdk::Client.new(
+                                     :endpoint => @aliyun_oss_endpoint,
+                                     :access_key_id => @aliyun_accesskey_id,
+                                     :access_key_secret => @aliyun_accesskey_secret
+          )
         end
 
         def reload

--- a/spec/fog/integration_spec.rb
+++ b/spec/fog/integration_spec.rb
@@ -16,6 +16,13 @@ describe 'Integration tests', :integration => true do
     system("aliyun oss mb oss://#{@conn.aliyun_oss_bucket} > /dev/null")
   end
 
+  it 'test get file that not exists' do
+    directory = @conn.directories.get(@conn.aliyun_oss_bucket)
+    files = directory.files
+    file = files.get('test_dir/test_file_not_exists')
+    expect(file).to eq(nil)
+  end
+
   it 'Should get all directories in bucket' do
     system("aliyun oss mkdir oss://#{@conn.aliyun_oss_bucket}/test_dir1 > /dev/null")
     system("aliyun oss mkdir oss://#{@conn.aliyun_oss_bucket}/test_dir2 > /dev/null")
@@ -198,8 +205,8 @@ describe 'Integration tests', :integration => true do
       dir = bucket.files.get("test_dir/").directory
       files = dir.files
       expect(files.empty?).to eq(false)
-      # In AWS the path & key is test_dir/test_file
-      expect(files.get("test_file").key).to eq("test_file")
+      expect(files.length).to eq(2)
+      expect(files.get("test_dir/test_file").key).to eq("test_dir/test_file")
     ensure
       file.close
       file.unlink


### PR DESCRIPTION
The performance result as following:
```
                user     system      total        real
Download file time:  0.440000   0.080000   0.520000 (  7.156471)
Total allocated: 45.14 MB (13212 objects)
Total retained:  5.86 MB (2773 objects)

allocated memory by gem
-----------------------------------
  32.05 MB  other
   5.97 MB  net
   5.27 MB  fog-aliyun/lib
   1.05 MB  timeout
 237.74 kB  openssl
 164.21 kB  rubygems
 143.27 kB  rexml
  75.57 kB  excon-0.72.0
  68.05 kB  time
  30.06 kB  xml-simple-1.1.5
  20.52 kB  aliyun-sdk-0.7.1
  17.11 kB  rest-client-2.1.0
  11.57 kB  socket
   8.65 kB  http-cookie-1.0.3
   8.35 kB  set
   6.93 kB  uri
   6.62 kB  fog-core-2.2.0
   2.30 kB  netrc-0.11.0
   1.75 kB  cgi
   1.45 kB  http-accept-1.7.0
   1.26 kB  domain_name-0.5.20190701
  768.00 B  logger
  747.00 B  base64
  352.00 B  monitor
```